### PR TITLE
Feat/reorganise pages

### DIFF
--- a/src/assets/caret-down.svg
+++ b/src/assets/caret-down.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-down-fill" viewBox="0 0 16 16">
+  <path d="M7.247 11.14 2.451 5.658C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z"/>
+</svg>

--- a/src/components/data/biographies.js
+++ b/src/components/data/biographies.js
@@ -248,7 +248,7 @@ export const languages = [
 export const works = [
   {
     name: 'FlyEasy',
-    desc: 'Self-initiated project. Concept website for a fictitious travel agency based in Malaysia, with the purpose of practising the use of Bootstrap components and framework.',
+    desc: "Self-initiated project. Concept website for a fictitious travel agency based in Malaysia, with the purpose of practising the use of Bootstrap's components.",
     link: 'https://stephjohnsons.com/flyeasy/'
   },
   {
@@ -265,6 +265,11 @@ export const works = [
     name: 'Weather App',
     desc: "Self-initiated project. An app that generates weather information of a local city based on user's search.",
     link: 'https://stephjohnsons.com/weather-app/'
+  },
+  {
+    name: 'Karl Thöne',
+    desc: "Website created for Datin Veronika Thöne's father, Karl (1924-1993), who was a German composer of contemporary music. The website is created in conjunction of his 100th birthday in 2024 and the '100th Anniversary Festival', which will feature world premiere of his Concertino and Malaysian premiere of some of his chamber works. Website is completed and under vetting; it will be published soon (June 2024).",
+    link: '-'
   }
 ]
 

--- a/src/components/data/pages.js
+++ b/src/components/data/pages.js
@@ -4,20 +4,25 @@ export const pageLinks = [
     link: '/'
   },
   {
-    name: '🎵 Bio',
-    link: '/bio'
-  },
-  {
-    name: '🎵 Projects',
-    link: '/projects'
-  },
-  {
-    name: '🎵 Media Gallery',
-    link: '/gallery'
-  },
-  {
-    name: '🎵 Upcoming Dates',
-    link: '/dates'
+    name: '🎵 Music',
+    children: [
+      {
+        name: 'Bio',
+        link: '/bio'
+      },
+      {
+        name: 'Projects',
+        link: '/projects'
+      },
+      {
+        name: 'Media Gallery',
+        link: '/gallery'
+      },
+      {
+        name: 'Upcoming Dates',
+        link: '/dates'
+      }
+    ]
   },
   {
     name: '🧑🏻‍🏫 Teaching',

--- a/src/components/data/pages.js
+++ b/src/components/data/pages.js
@@ -4,32 +4,32 @@ export const pageLinks = [
     link: '/'
   },
   {
-    name: 'Projects',
-    link: '/projects'
-  },
-  {
-    name: 'Musician Bio',
+    name: '🎵 Bio',
     link: '/bio'
   },
   {
-    name: 'Vita',
+    name: '🎵 Projects',
+    link: '/projects'
+  },
+  {
+    name: '🎵 Media Gallery',
+    link: '/gallery'
+  },
+  {
+    name: '🎵 Upcoming Dates',
+    link: '/dates'
+  },
+  {
+    name: '🧑🏻‍🏫 Teaching',
+    link: '/teaching'
+  },
+  {
+    name: '🧑🏻‍💻 Vita',
     link: '/vita'
   },
   {
     name: 'Blog',
     link: '/blog'
-  },
-  {
-    name: 'Gallery',
-    link: '/gallery'
-  },
-  {
-    name: 'Dates',
-    link: '/dates'
-  },
-  {
-    name: 'Teaching',
-    link: '/teaching'
   },
   {
     name: 'Contact',

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -26,8 +26,9 @@
       He also has a keen interest in software development and enjoys reading.
     </p>
     <p>
-      <RouterLink :to="{ path: pageLinks[2].link }" class="text-muted">musician bio</RouterLink>
+      <RouterLink :to="{ path: pageLinks[1].children[0].link }" class="text-muted">musician bio</RouterLink>
       <RouterLink :to="{ path: pageLinks[3].link }" class="text-muted ms-3">developer bio</RouterLink>
+      <RouterLink :to="{ path: pageLinks[2].link }" class="text-muted ms-3">teaching bio</RouterLink>
     </p>
   </main>
 </template>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -26,9 +26,8 @@
       He also has a keen interest in software development and enjoys reading.
     </p>
     <p>
-      <RouterLink :to="{ path: pageLinks[1].link }" class="text-muted">
-        read more here
-      </RouterLink>
+      <RouterLink :to="{ path: pageLinks[2].link }" class="text-muted">musician bio</RouterLink>
+      <RouterLink :to="{ path: pageLinks[3].link }" class="text-muted ms-3">developer bio</RouterLink>
     </p>
   </main>
 </template>
@@ -64,19 +63,6 @@ onMounted(() => {
 </script>
 
 <style scoped>
-/* .home-image {
-  position: absolute;
-  left: calc(-35% + 12vw);
-}
-
-@media (min-width: 992px) {
-  .home-image {
-    left: calc(-25% + 15vw);
-  }
-} */
-
-/* 
- */
 .image-container {
   display: inline-block;
   position: relative;
@@ -117,6 +103,10 @@ onMounted(() => {
   .anti-caption {
     opacity: 0;
   }
+}
+
+.text-muted:hover {
+  color: #19191A !important;
 }
 
 @media (min-width: 992px) {

--- a/src/views/MenuView.vue
+++ b/src/views/MenuView.vue
@@ -2,8 +2,8 @@
   <div class="h-100 text-center my-5">
     <nav class="d-flex flex-column fs-3 my-3" v-for="(item, index) of pageLinks" :key="item.name">
       <Transition name="slide-fade" appear>
-        <RouterLink :to="{ path: item.link }" :style="{ transitionDelay: `${index * 0.05}s` }" @mouseover="rotateArrow"
-          @mouseleave="resetArrow">
+        <RouterLink v-if="!item.children" :to="{ path: item.link }" :style="{ transitionDelay: `${index * 0.05}s` }"
+          @mouseover="rotateArrow" @mouseleave="resetArrow">
           <span id="item">{{ item.name }}</span>
           <svg xmlns="http://www.w3.org/2000/svg" width="38" height="38" fill="currentColor"
             class="bi bi-arrow-right-short" viewBox="0 0 16 16"
@@ -12,6 +12,26 @@
               d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8" />
           </svg>
         </RouterLink>
+        <div v-else>
+          <span id="menu-item" @click="submenuToggle()">{{ item.name }}
+            <CaretDown id="menu-caret" :class="{ rotated: !toggle }" />
+          </span>
+          <Transition name="submenu-fade">
+            <div class="nested-menu d-flex flex-column mb-2" v-if="toggle">
+              <router-link v-for="(child, index) in item.children" :key="child.name" :to="child.link"
+                :style="{ transitionDelay: `${index * 0.05}s` }" @mouseover="rotateArrow" @mouseleave="resetArrow"
+                id="menu-child-item">
+                <span id="item">{{ child.name }}</span>
+                <svg xmlns="http://www.w3.org/2000/svg" width="38" height="38" fill="currentColor"
+                  class="bi bi-arrow-right-short" viewBox="0 0 16 16"
+                  style="transform: rotate(-45deg); transition: 0.2s ease;">
+                  <path fill-rule="evenodd"
+                    d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8" />
+                </svg>
+              </router-link>
+            </div>
+          </Transition>
+        </div>
       </Transition>
     </nav>
 
@@ -30,9 +50,13 @@
 </template>
 
 <script setup>
+import { ref } from 'vue'
 import { pageLinks } from '@/components/data/pages.js'
 import { RouterLink } from 'vue-router'
+import CaretDown from '@/assets/caret-down.svg'
 import SocialIcons from '@/components/SocialIcons.vue'
+
+const toggle = ref(false);
 
 const rotateArrow = (event) => {
   event.currentTarget.querySelector('.bi-arrow-right-short').style.transform = 'rotate(0deg)';
@@ -40,6 +64,10 @@ const rotateArrow = (event) => {
 
 const resetArrow = (event) => {
   event.currentTarget.querySelector('.bi-arrow-right-short').style.transform = 'rotate(-45deg)';
+}
+
+const submenuToggle = () => {
+  toggle.value = !toggle.value;
 }
 </script>
 
@@ -52,17 +80,28 @@ p {
   margin: 0;
 }
 
+#menu-child-item {
+  color: #777 !important;
+}
+
 nav>a {
   color: #19191A !important;
+}
+
+nav>a,
+#menu-child-item {
   transition: 200ms cubic-bezier(.29, .57, .94, .61);
   text-decoration: underline;
 }
 
-nav>a.bi-arrow-right {
+nav>a.bi-arrow-right,
+#menu-child-item>a.bi-arrow-right {
   translate: rotate(90deg);
 }
 
-nav>a:hover {
+nav>a:hover,
+#menu-child-item:hover {
+  color: #19191A !important;
   background-position: 0 100%;
   background-repeat: repeat;
   transition: 200ms cubic-bezier(.29, .57, .94, .61);
@@ -106,25 +145,50 @@ a>span:hover {
   }
 
   #item::after {
-    content: ''; 
+    content: '';
     position: absolute;
-    bottom: 0; 
+    bottom: 0;
     left: 10%;
     right: -5%;
-    height: 40%; 
-    background-color: rgb(252, 192, 14); 
-    z-index: -1; 
+    height: 40%;
+    background-color: rgb(252, 192, 14);
+    z-index: -1;
     transition: 100ms cubic-bezier(.29, .57, .94, .61);
   }
 
   #item:hover::after {
     position: absolute;
     left: -5%;
-    background-color: rgb(252, 192, 14); 
+    background-color: rgb(252, 192, 14);
   }
 
   svg {
     opacity: 0;
   }
+}
+
+#menu-item,
+#menu-caret {
+  cursor: pointer;
+}
+
+#menu-caret {
+  transition: transform 0.3s ease;
+}
+
+.rotated {
+  transform: rotate(180deg);
+  transition: transform 0.3s ease;
+}
+
+.submenu-fade-enter-active,
+.submenu-fade-leave-active {
+  transition: all 0.2s ease-out;
+}
+
+.submenu-fade-enter-from,
+.submenu-fade-leave-to {
+  transform: translateY(-10px);
+  opacity: 0;
 }
 </style>

--- a/src/views/ProjectsView.vue
+++ b/src/views/ProjectsView.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="about">
-    <h2 class="mb-0">Past Projects and Concerts</h2>
+    <h2 class="mb-0">Past Musical Projects and Concerts</h2>
     <p class="text-muted small">Sorted by starting year in descending order.</p>
 
     <div class="d-flex align-items-center gap-1 my-2">


### PR DESCRIPTION
Reorganised the pages on the website so that navigation is clearer. 

- Separated sections between my musician profile and developer profile (so that it's easier for recruiters to see my portfolio) 
- Make navigation more intuitive on menu page: created submenu for musician profiles and sections 
- Added another link on main page so that different visitors could quickly navigate to my separate bios quickly 

I also added another project titled "Karl Thoene" that is yet published. The website shall be updated again when the site is published.